### PR TITLE
Add React map UI with chat drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ For rapid iteration without rebuilding the Dash container:
     python3 -m geo_assistant.load_parcels
     ```
 
+
+### React Frontend
+
+A lightweight React application is provided in the `webapp` directory. It displays a fullscreen map and an optional chat drawer on the right.
+
+Run it locally with:
+
+```bash
+cd webapp
+npm install
+npm run start
+```
+
+The app will start with Vite on http://localhost:5173 by default.
+
 ## Contributing
 
 1. Fork the repository and create a feature branch.

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "geoassistant-webapp",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "mapbox-gl": "^2.15.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  },
+  "scripts": {
+    "start": "vite",
+    "build": "vite build"
+  }
+}

--- a/webapp/public/index.html
+++ b/webapp/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoAssistant Map</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/webapp/src/App.css
+++ b/webapp/src/App.css
@@ -1,0 +1,49 @@
+html, body, #root, .app {
+  height: 100%;
+  margin: 0;
+}
+
+.map-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.chat-toggle {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  z-index: 10;
+  padding: 8px 12px;
+}
+
+.drawer {
+  position: fixed;
+  top: 0;
+  right: -25%;
+  width: 25%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: -2px 0 5px rgba(0,0,0,0.3);
+  transition: right 0.3s ease-in-out;
+  z-index: 9;
+  display: flex;
+  flex-direction: column;
+}
+
+.drawer.open {
+  right: 0;
+}
+
+.drawer-header {
+  padding: 10px;
+  border-bottom: 1px solid #ccc;
+}
+
+.drawer-body {
+  flex: 1;
+  overflow: auto;
+  padding: 10px;
+}

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -1,0 +1,32 @@
+import React, { useRef, useEffect, useState } from 'react';
+import mapboxgl from 'mapbox-gl';
+import ChatDrawer from './ChatDrawer';
+
+// Set your Mapbox token here
+mapboxgl.accessToken = 'YOUR_MAPBOX_ACCESS_TOKEN';
+
+export default function App() {
+  const mapContainer = useRef(null);
+  const map = useRef(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (map.current) return; // initialize map only once
+    map.current = new mapboxgl.Map({
+      container: mapContainer.current,
+      style: 'https://api.maptiler.com/maps/streets/style.json?key=GET_YOUR_OWN',
+      center: [-74.006, 40.7128],
+      zoom: 10,
+    });
+  }, []);
+
+  return (
+    <div className="app">
+      <div className="map-container" ref={mapContainer} />
+      <button className="chat-toggle" onClick={() => setIsOpen(!isOpen)}>
+        Chat
+      </button>
+      <ChatDrawer open={isOpen} onClose={() => setIsOpen(false)} />
+    </div>
+  );
+}

--- a/webapp/src/ChatDrawer.js
+++ b/webapp/src/ChatDrawer.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export default function ChatDrawer({ open, onClose }) {
+  return (
+    <div className={`drawer ${open ? 'open' : ''}`}>
+      <div className="drawer-header">
+        <button onClick={onClose}>Close</button>
+      </div>
+      <div className="drawer-body">
+        <p>Chat content goes here.</p>
+      </div>
+    </div>
+  );
+}

--- a/webapp/src/index.js
+++ b/webapp/src/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './App.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/webapp/vite.config.js
+++ b/webapp/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    open: true
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `webapp` React project using Vite
- implement fullscreen Mapbox map with a slide-out chat drawer
- document how to run the React frontend in README

## Testing
- `pytest -q` *(fails: pyenv version `gis` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68525750405c8331bfd2b2d77c7b7847