### PR TITLE
Add React map with chat drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,14 @@ For rapid iteration without rebuilding the Dash container:
    pip install -r requirements.txt
    python3 -m geo_assistant.app
    ```
-3. Tail service logs:
+3. Start the React frontend with Vite:
+
+   ```bash
+   cd frontend
+   npm install
+   npm run dev
+   ```
+4. Tail service logs:
 
    ```bash
    docker-compose logs -f geo_assistant  # AI + API server

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "geoassistant-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-leaflet": "^4.2.1",
+    "leaflet": "^1.9.4",
+    "@mui/material": "^5.14.4",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.9"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GeoAssistant Map</title>
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,4 @@
+.app-container {
+  height: 100vh;
+  width: 100vw;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { MapContainer, TileLayer } from 'react-leaflet';
+import ChatDrawer from './ChatDrawer';
+import Button from '@mui/material/Button';
+import './App.css';
+
+function App() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="app-container">
+      <MapContainer
+        center={[40.7128, -74.006]}
+        zoom={13}
+        style={{ height: '100vh', width: '100vw' }}
+      >
+        <TileLayer
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          attribution="&copy; OpenStreetMap contributors"
+        />
+      </MapContainer>
+      <Button
+        variant="contained"
+        onClick={() => setOpen(true)}
+        style={{ position: 'absolute', top: 10, right: 10, zIndex: 1000 }}
+      >
+        Chat
+      </Button>
+      <ChatDrawer open={open} onClose={() => setOpen(false)} />
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/ChatDrawer.jsx
+++ b/frontend/src/ChatDrawer.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Drawer from '@mui/material/Drawer';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+function ChatDrawer({ open, onClose }) {
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{
+        sx: {
+          width: '25vw',
+          maxWidth: '400px',
+          bgcolor: 'rgba(255, 255, 255, 0.9)'
+        }
+      }}
+    >
+      <Box p={2} sx={{ height: '100%' }}>
+        <Typography variant="h6">Chat</Typography>
+        {/* Chat content can be added here */}
+      </Box>
+    </Drawer>
+  );
+}
+
+export default ChatDrawer;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,4 @@
+html, body, #root {
+  margin: 0;
+  height: 100%;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- create a new `frontend` React app using Vite
- implement a Leaflet map that fills the screen
- add a floating "Chat" button that opens an opaque drawer
- update README with instructions for running the React frontend

## Testing
- `pytest -q` *(fails: pyenv: version `gis` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68525a9fb8d48331a017469895f2eb29