### PR TITLE
Remove stray citation artifacts

### DIFF
--- a/geo_assistant/handlers/_map_handler.py
+++ b/geo_assistant/handlers/_map_handler.py
@@ -102,7 +102,7 @@ class MapHandler:
                     "source": [
                         self._get_base_tileurl(table) + "&filter=" + filter_
                     ],
-                    "sourcelayer": table,                  # ← must match your tileset name :contentReference[oaicite:0]{index=0}
+                    "sourcelayer": table,                  # ← must match your tileset name
                     "type": style,                                 # draw lines
                     "color": color,
                     "below": "traces" 
@@ -118,7 +118,7 @@ class MapHandler:
                 "source": [
                     self._get_base_tileurl(table)
                 ],
-                "sourcelayer": table,                  # ← must match your tileset name :contentReference[oaicite:0]{index=0}
+                "sourcelayer": table,                  # ← must match your tileset name
                 "type": style,                                 # draw lines
                 "color": color,
                 "below": "traces" 


### PR DESCRIPTION
## Summary
- clean up MapHandler by removing leftover citation references in layer definitions

## Testing
- `pytest -q` *(fails: `pyenv: version 'gis' is not installed`)*

------
https://chatgpt.com/codex/tasks/task_e_685a29e367d8833182278a5e81136217